### PR TITLE
Update CalendarMonth__caption text align

### DIFF
--- a/css/CalendarMonth.scss
+++ b/css/CalendarMonth.scss
@@ -31,7 +31,7 @@
   margin-top: 7px;
   font-size: 18px;
   padding: 15px 0 35px;
-
+  text-align: center;
   // necessary to not hide borders in FF
   margin-bottom: 2px;
 }


### PR DESCRIPTION
The caption conflicted with Bootstrap.  Bootstrap placed the caption to the left while the calendar month has to have the caption. This forces the issue.
